### PR TITLE
BRS: Add compatability for Luegis Font Icons (Loyalty)

### DIFF
--- a/BRS/RealModifierAnalysis.lua
+++ b/BRS/RealModifierAnalysis.lua
@@ -15,6 +15,9 @@ local bIsRiseAndFallMod:boolean = Modding.IsModActive("1B28771A-C749-434B-9053-D
 local bIsGatheringStorm:boolean = Modding.IsModActive("4873eb62-8ccc-4574-b784-dda455e74e68"); -- Gathering Storm
 local bIsRiseAndFall:boolean = (bIsRiseAndFallMod or bIsGatheringStorm); -- GS includes gameplay features from RF
 
+-- Mod compatibilities check
+local bIsLuegiFontIconsMod = Modding.IsModActive("2ede4527-c961-4344-9cd1-859ff570d401"); -- Appeal, Loyalty and Prestige (Diplo VP) Font Icons (Luegi)
+
 
 -- ===========================================================================
 -- DEBUG ROUTINES
@@ -259,6 +262,7 @@ end
 --	returns		The [ICON_yield] string
 -- ===========================================================================
 function GetYieldTextIcon( yieldType:string )
+
 	local  iconString:string = "";
 	if		yieldType == nil or yieldType == ""	then
 		iconString = "Error:NIL";
@@ -269,7 +273,7 @@ function GetYieldTextIcon( yieldType:string )
 	elseif  yieldType == "YIELD_HOUSING" then
 		iconString = "[ICON_Housing]" -- [ICON_LocationPip] a blue pin pointing down
 	elseif  yieldType == "YIELD_LOYALTY" then
-		iconString = "[ICON_PressureUp]" -- [ICON_PressureDown] is a red arrow pointing down
+		iconString = bIsLuegiFontIconsMod and "[ICON_Loyalty]" or "[ICON_PressureUp]" -- [ICON_PressureDown] is a red arrow pointing down
 	elseif	GameInfo.Yields[yieldType] ~= nil and GameInfo.Yields[yieldType].IconString ~= nil and GameInfo.Yields[yieldType].IconString ~= "" then
 		iconString = GameInfo.Yields[yieldType].IconString;
 	else

--- a/BRS/ReportScreen.lua
+++ b/BRS/ReportScreen.lua
@@ -21,6 +21,9 @@ print("Rise & Fall    :", (bIsRiseFall and "YES" or "no"));
 local bIsGatheringStorm:boolean = Modding.IsModActive("4873eb62-8ccc-4574-b784-dda455e74e68"); -- Gathering Storm
 print("Gathering Storm:", (bIsGatheringStorm and "YES" or "no"));
 
+-- Mod compatibilities check
+local bIsLuegiFontIconsMod = Modding.IsModActive("2ede4527-c961-4344-9cd1-859ff570d401"); -- Appeal, Loyalty and Prestige (Diplo VP) Font Icons (Luegi)
+
 -- configuration options
 local bOptionModifiers:boolean = ( GlobalParameters.BRS_OPTION_MODIFIERS == 1 );
 
@@ -3249,7 +3252,7 @@ function city_fields( kCityData, pCityInstance )
 	local currentLoyalty = pCulturalIdentity:GetLoyalty();
 	local maxLoyalty = pCulturalIdentity:GetMaxLoyalty();
 	local loyaltyPerTurn:number = pCulturalIdentity:GetLoyaltyPerTurn();
-	local loyaltyFontIcon:string = loyaltyPerTurn >= 0 and "[ICON_PressureUp]" or "[ICON_PressureDown]";
+	local loyaltyFontIcon:string = bIsLuegiFontIconsMod and "[ICON_Loyalty]" or (loyaltyPerTurn >= 0 and "[ICON_PressureUp]" or "[ICON_PressureDown]");
 	local iNumTurnsLoyalty:number = 0;
 	if loyaltyPerTurn > 0 then
 		iNumTurnsLoyalty = math.ceil((maxLoyalty-currentLoyalty)/loyaltyPerTurn);
@@ -4268,6 +4271,7 @@ function ViewPolicyPage()
 		if policyGroup == "SLOT_PANTHEON" or policyGroup == "SLOT_FOLLOWER" then pHeaderInstance.PolicyHeaderLabelName:SetText( Locale.Lookup("LOC_BELIEF_NAME") ); end
 		local iNumRows:number = 0;
 		pHeaderInstance.PolicyHeaderButtonLOYALTY:SetHide( not (bIsRiseFall or bIsGatheringStorm) );
+		pHeaderInstance.PolicyHeaderButtonLabelLOYALTY:SetText( bIsLuegiFontIconsMod and "[ICON_Loyalty]" or "[ICON_PressureUp]" )
 		
 		-- set sorting callbacks
 		--if pHeaderInstance.UnitTypeButton then     pHeaderInstance.UnitTypeButton:RegisterCallback(    Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "type", iUnitGroup, instance ) end ) end
@@ -4540,6 +4544,7 @@ function ViewMinorPage()
 		pHeaderInstance.PolicyHeaderLabelName:SetText( Locale.Lookup("LOC_HUD_REPORTS_CITY_STATE") );
 		local iNumRows:number = 0;
 		pHeaderInstance.PolicyHeaderButtonLOYALTY:SetHide( not (bIsRiseFall or bIsGatheringStorm) );
+		pHeaderInstance.PolicyHeaderButtonLabelLOYALTY:SetText( bIsLuegiFontIconsMod and "[ICON_Loyalty]" or "[ICON_PressureUp]" )
 		
 		-- set sorting callbacks
 		--if pHeaderInstance.UnitTypeButton then     pHeaderInstance.UnitTypeButton:RegisterCallback(    Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "type", iUnitGroup, instance ) end ) end

--- a/BRS/ReportScreen.xml
+++ b/BRS/ReportScreen.xml
@@ -2007,7 +2007,7 @@
 				
 				<Container Offset="0,0" Size="45,parent">
 					<GridButton ID="PolicyHeaderButtonLOYALTY"  ToolTip="LOC_REPORTS_LOYALTY" Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-						<Label Style="ReportHeaderSmallText" String="[ICON_PressureUp]"/>
+						<Label ID="PolicyHeaderButtonLabelLOYALTY" Style="ReportHeaderSmallText" String="$PolicyHeaderButtonLabelLOYALTYString$"/>
 					</GridButton>
 				</Container>
 				

--- a/BRS/RiseFall/ReportScreen.xml
+++ b/BRS/RiseFall/ReportScreen.xml
@@ -2003,7 +2003,7 @@
 				
 				<Container Offset="0,0" Size="45,parent">
 					<GridButton ID="PolicyHeaderButtonLOYALTY"  ToolTip="LOC_REPORTS_LOYALTY" Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-						<Label Style="ReportHeaderSmallText" String="[ICON_PressureUp]"/>
+						<Label ID="PolicyHeaderButtonLabelLOYALTY" Style="ReportHeaderSmallText" String="$PolicyHeaderButtonLabelLOYALTYString$" />
 					</GridButton>
 				</Container>
 				


### PR DESCRIPTION
Hello!

I've created this pull request to add support for the following workshop mod:
* [Appeal, Loyalty and Prestige (Diplo VP) Font Icons](https://steamcommunity.com/sharedfiles/filedetails/?id=1987147435) by the Steam user [Luegi](https://steamcommunity.com/profiles/76561198082179827)

I really like using these two mods together, and always thought it would be nice if the Better Report Screen could use the Luegi font icon `[ICON_Loyalty]` in the headers.

See the below screenshot for the end result.

![Capture2](https://user-images.githubusercontent.com/7817695/103976080-a85bd900-512a-11eb-8d66-e7178950de96.PNG)

And below, a bit closer.

![Capture3](https://user-images.githubusercontent.com/7817695/103976297-3e8fff00-512b-11eb-9375-ccaa8ab1879e.png)


This also plays nicely with [Extended Policy Cards](https://steamcommunity.com/sharedfiles/filedetails/?id=2266952591) by Steam user [Aristos](https://steamcommunity.com/profiles/76561198076699209).

See the below screenshot to see the Better Report Screen yields on a policy card and playing nicely with the loyalty icon.

![Capture1](https://user-images.githubusercontent.com/7817695/103976115-bf023000-512a-11eb-9493-944c056a02ea.PNG)

Feel free to give any feedback. I am a senior software engineer.

