### PR TITLE
RFX: More text fixes.

### DIFF
--- a/RFX/real_fixes_text.xml
+++ b/RFX/real_fixes_text.xml
@@ -13,6 +13,18 @@
 	</Replace>
 	<Replace Tag="LOC_TRAIT_LEADER_LITHUANIAN_UNION_HEROES_DESCRIPTION" Language="en_US">
 		<Text>The Religion founded by Poland becomes the majority in an adjacent city that loses a tile to a Polish Culture Bomb. Holy Sites gain standard [ICON_FAITH] Faith adjacency bonus from adjacent districts. [ICON_GreatWork_Relic] Relics and [ICON_GreatWork_HeroRelic] Heroic Relics provide +2 [ICON_Faith] Faith, +2 [ICON_Culture] Culture, +4 [ICON_Gold] Gold.</Text>
-	</Replace>		
+	</Replace>
+	<Replace Tag="LOC_BOOST_TRIGGER_LONGDESC_SIEGE_TACTICS">
+		<Text>After creating trebuchets you realize that castles are not impregnable – you need a stauncher defense!</Text>
+	</Replace>	
+	<Replace Tag="LOC_TECH_TREE_TURNS">
+		<Text>{1_Turns : plural 1?{1_Turns} TURN; other? {1_Turn} TURNS;}</Text>
+	</Replace>
+	<Replace Tag="LOC_GREATWORK_TCHAIKOVSKY_1_NAME">
+		<Text>1812 Overture</Text>
+	</Replace>
+	<Replace Tag="LOC_TECH_SMART_MATERIALS_DESCRIPTION">
+		<Text>Unlocks Giant Death Robot upgrade: Reinforced Armor Plating[NEWLINE]+10 [ICON_Strength] Combat Strength when defending against land and naval units.[NEWLINE]+1 [ICON_Production] Production to the Mine improvement.</Text>
+	</Replace>
   </LocalizedText>
 <GameData>


### PR DESCRIPTION
- Fix long description for siege tactics eureka
- Fix capitalization of TURN in tech/civic tree (when there is 1 turn)
- Fix Tchaikovsky great work name
- Add missing +1 Production to Smart Materials description