### PR TITLE
BLI: Add Compatibility for Custom Alliances

### DIFF
--- a/BLI/Base/leadericon.lua
+++ b/BLI/Base/leadericon.lua
@@ -331,10 +331,11 @@ function LeaderIcon:GetRelationToolTipString(playerID:number)
 		local allianceType = localPlayerDiplomacy:GetAllianceType(playerID);
 		if allianceType ~= -1 then
 			local info:table = GameInfo.Alliances[allianceType];
-			--table.insert(tTT, tAllianceIcons[info.AllianceType]..LL(info.Name).." "..LL("LOC_DIPLOACTION_ALLIANCE_LEVEL", localPlayerDiplomacy:GetAllianceLevel(playerID)));
-			table.insert(tTT, tAllianceIcons[info.AllianceType]..LL(info.Name).." "..string.rep("[ICON_AllianceBlue]", localPlayerDiplomacy:GetAllianceLevel(playerID)));
+			local allianceIcon = tAllianceIcons[info.AllianceType] or "";
+			--table.insert(tTT, allianceIcon..LL(info.Name).." "..LL("LOC_DIPLOACTION_ALLIANCE_LEVEL", localPlayerDiplomacy:GetAllianceLevel(playerID)));
+			table.insert(tTT, allianceIcon..LL(info.Name).." "..string.rep("[ICON_AllianceBlue]", localPlayerDiplomacy:GetAllianceLevel(playerID)));
 			local iTurns:number = localPlayerDiplomacy:GetAllianceTurnsUntilExpiration(playerID);
-			local sExpires:string = tAllianceIcons[info.AllianceType]..LL("LOC_DIPLOACTION_EXPIRES_IN_X_TURNS", iTurns);
+			local sExpires:string = allianceIcon..LL("LOC_DIPLOACTION_EXPIRES_IN_X_TURNS", iTurns);
 			sExpires = string.gsub(sExpires, "%(", "");
 			sExpires = string.gsub(sExpires, "%)", "");
 			if iTurns < 4 then sExpires = ColorRED(sExpires); end


### PR DESCRIPTION
Adds compatibility for mods that add custom alliances by not requiring an alliance icon to be defined in the tAllianceIcons table.

Previously, if the player was in a custom alliance with somebody, tAllianceIcons[info.AllianceType] would return nil, which would cause issues such as the entire UI breaking. This will no longer happen with this change.

I simply made it so that an empty string will be used if no icon is defined in the tAllianceIcons table. I tried using some other icons like [ICON_AllianceBlue] or [ICON_Alliance] instead of an empty string, but I didn't quite like how they looked. This default value can always be changed later though, and new icons could be defined in the table as well if desired.