### PR TITLE
RTT: fix inspiration for Near Future Governance

### DIFF
--- a/RTT/RTT_Boosts.sql
+++ b/RTT/RTT_Boosts.sql
@@ -3,9 +3,9 @@
 -- Eurekas boost for Technologies
 UPDATE Boosts
 	SET Boost = 35
-	WHERE TechnologyType IS NOT NULL;
+	WHERE TechnologyType IS NOT NULL AND Boost <= 50;
 
 -- Eurekas boost for Civics
 UPDATE Boosts
 	SET Boost = 35
-	WHERE CivicType IS NOT NULL;
+	WHERE CivicType IS NOT NULL AND Boost <= 50;


### PR DESCRIPTION
Near Future Governance has a 90% inspiration by default. I suggest keeping that, or maybe lowering it to 85% or something.